### PR TITLE
fix: implement proper AssemblyAI polling for transcription

### DIFF
--- a/src/lib/transcription-processor.ts
+++ b/src/lib/transcription-processor.ts
@@ -131,21 +131,46 @@ export async function processTranscription(params: {
         
         console.log('[TranscriptionProcessor] Calling assembly.transcripts.transcribe()...')
         
-        // Add timeout to prevent hanging forever (5 minutes max)
-        const transcribePromise = assembly.transcripts.transcribe(params)
-        const timeoutPromise = new Promise<never>((_, reject) => 
-          setTimeout(() => reject(new Error('AssemblyAI transcription timeout after 5 minutes')), 300000)
-        )
-        
-        const transcript = await Promise.race([transcribePromise, timeoutPromise])
-        console.log('[TranscriptionProcessor] AssemblyAI response received:', {
-          status: transcript.status,
-          id: transcript.id,
-          hasText: !!transcript.text,
-          textLength: transcript.text?.length || 0,
-          hasWords: !!transcript.words,
-          wordsCount: transcript.words?.length || 0
+        // Submit transcription request
+        const submittedTranscript = await assembly.transcripts.submit(params)
+        console.log('[TranscriptionProcessor] AssemblyAI job submitted:', {
+          id: submittedTranscript.id,
+          status: submittedTranscript.status
         })
+
+        // Poll for completion with proper progress updates
+        let pollingAttempts = 0
+        const maxPollingAttempts = 60 // 5 minutes with 5-second intervals
+        let completedTranscript = submittedTranscript
+        
+        while (completedTranscript.status === 'queued' || completedTranscript.status === 'processing') {
+          if (pollingAttempts >= maxPollingAttempts) {
+            throw new Error('AssemblyAI transcription timeout after 5 minutes')
+          }
+          
+          // Wait 5 seconds before polling
+          await new Promise(resolve => setTimeout(resolve, 5000))
+          pollingAttempts++
+          
+          // Get updated status
+          completedTranscript = await assembly.transcripts.get(submittedTranscript.id)
+          console.log(`[TranscriptionProcessor] Polling attempt ${pollingAttempts}/${maxPollingAttempts}, status: ${completedTranscript.status}`)
+          
+          // Update progress based on polling attempts (30% to 60%)
+          const progress = 30 + Math.floor((pollingAttempts / maxPollingAttempts) * 30)
+          await ProjectService.updateTaskProgress(projectId, 'transcription', Math.min(progress, 55), 'processing')
+        }
+        
+        console.log('[TranscriptionProcessor] AssemblyAI transcription completed:', {
+          status: completedTranscript.status,
+          id: completedTranscript.id,
+          hasText: !!completedTranscript.text,
+          textLength: completedTranscript.text?.length || 0,
+          hasWords: !!completedTranscript.words,
+          wordsCount: completedTranscript.words?.length || 0
+        })
+        
+        const transcript = completedTranscript
 
         // Update progress to 60% after transcription
         await ProjectService.updateTaskProgress(projectId, 'transcription', 60, 'processing')


### PR DESCRIPTION
- Fixed transcription hanging at 30% by implementing proper async polling
- AssemblyAI transcription is a 2-step process: submit then poll for results
- Added progress updates during polling (30% to 60%)
- Polls every 5 seconds for up to 5 minutes